### PR TITLE
Fix conflicting keybindings for "fullscreen" and "find" on macOS (CMD+F)

### DIFF
--- a/src/views/keyevents/Keybindings.ts
+++ b/src/views/keyevents/Keybindings.ts
@@ -116,7 +116,6 @@ export type KeybindingMenuType = {
 };
 
 const CopyAccelerator = process.platform === "darwin" ? "Command+C" : "Ctrl+Shift+C";
-const ToggleFullScreenAccelerator = process.platform === "darwin" ? "Command+F" : "Ctrl+Shift+F";
 
 export const KeybindingsForMenu: KeybindingMenuType[] = [
     {
@@ -196,7 +195,7 @@ export const KeybindingsForMenu: KeybindingMenuType[] = [
     },
     {
         action: KeyboardAction.viewToggleFullScreen,
-        accelerator: ToggleFullScreenAccelerator,
+        accelerator: "CmdOrCtrl+Shift+F",
     },
     // black screen commands
     {


### PR DESCRIPTION
On macOS, `Edit>Find` has the same keybinding as `View>Toogle Full Screen`, namely `CMD+F`.

This pull request reassigns full screen to `CMD+Shift+F` on mac. As a side-effect, the accelerator can be unified to `CmdOrCtrl+Shift+F` which is equal to the previous mapping on all other operating systems.