### PR TITLE
Scroll prompt into view when cycling history

### DIFF
--- a/src/views/4_PromptComponent.tsx
+++ b/src/views/4_PromptComponent.tsx
@@ -251,6 +251,12 @@ export class PromptComponent extends React.Component<Props, State> {
         this.setText(this.prompt.value.concat(text));
     }
 
+    scrollIntoView(): void {
+        /* tslint:disable:no-string-literal */
+        this.commandNode.scrollIntoView(true);
+        document.location.href = `#${this.props.job.id}`;
+    }
+
     private setText(text: string): void {
         this.prompt.setValue(text);
         this.setDOMValueProgrammatically(text);

--- a/src/views/4_PromptComponent.tsx
+++ b/src/views/4_PromptComponent.tsx
@@ -252,9 +252,7 @@ export class PromptComponent extends React.Component<Props, State> {
     }
 
     scrollIntoView(): void {
-        /* tslint:disable:no-string-literal */
         this.commandNode.scrollIntoView(true);
-        document.location.href = `#${this.props.job.id}`;
     }
 
     private setText(text: string): void {

--- a/src/views/UserEventsHander.ts
+++ b/src/views/UserEventsHander.ts
@@ -183,6 +183,7 @@ export const handleUserEvent = (
             }
         } else {
             if (isKeybindingForEvent(event, KeyboardAction.cliHistoryPrevious)) {
+                prompt.scrollIntoView();
                 prompt.setPreviousHistoryItem();
 
                 event.stopPropagation();
@@ -191,6 +192,7 @@ export const handleUserEvent = (
             }
 
             if (isKeybindingForEvent(event, KeyboardAction.cliHistoryNext)) {
+                prompt.scrollIntoView();
                 prompt.setNextHistoryItem();
 
                 event.stopPropagation();


### PR DESCRIPTION
A common workflow for me is:

1) Run a command
2) Scroll up to see it's output
3) Switch to editor to edit something
4) Switch back, run press up to run same command
5) Repeat

When I do this, I want the prompt to scroll into view, so I
can see what I am actually about to execute. This PR makes that happen