### PR TITLE
Fix #927

### DIFF
--- a/src/plugins/autocompletion_utils/Common.ts
+++ b/src/plugins/autocompletion_utils/Common.ts
@@ -9,7 +9,7 @@ import {fontAwesome} from "../../views/css/FontAwesome";
 import {colors} from "../../views/css/colors";
 import {CSSObject} from "../../views/css/definitions";
 import {StatusCode} from "../../utils/Git";
-import {linedOutputOf} from "../../PTY";
+import {executeCommand} from "../../PTY";
 import {ASTNode, leafNodeAt, serializeReplacing} from "../../shell/Parser";
 
 type Style = { value: string; css: CSSObject};
@@ -228,7 +228,7 @@ const filesSuggestions = (filter: (info: FileInfo) => boolean) => async(tokenVal
         .filter(info => info.stat.isDirectory() || filter(info))
         .map(async info => {
             // Shell out to printf to ecape the filename, it is the only thing that truly knows how to do that
-            const escapedName: string = (await linedOutputOf("printf", ['"%q"', `"${info.name}"`], "/"))[0];
+            const escapedName: string = await executeCommand("printf", ['"%q"', `"${info.name}"`], "/");
             if (info.stat.isDirectory()) {
                 return new Suggestion({
                     value: joinPath(tokenDirectory, escapedName + Path.sep),

--- a/src/shell/Parser.ts
+++ b/src/shell/Parser.ts
@@ -316,16 +316,19 @@ export class ParameterAssignment extends LeafNode {
 }
 
 export class CommandWord extends LeafNode {
-    async suggestions(context: PreliminaryAutocompletionContext): Promise<Suggestion[]> {
+    async suggestions({
+        environment,
+        aliases,
+    }: PreliminaryAutocompletionContext): Promise<Suggestion[]> {
         if (this.value.length === 0) {
             return [];
         }
 
-        const relativeExecutablesSuggestions = await executableFilesSuggestions(this.value, context.environment.pwd);
-        const executables = await executablesInPaths(context.environment.path);
+        const relativeExecutablesSuggestions = await executableFilesSuggestions(this.value, environment.pwd);
+        const executables = await executablesInPaths(environment.path);
 
         return [
-            ...mapObject(context.aliases.toObject(), (key, value) => new Suggestion({value: key, description: value, style: styles.alias, space: true})),
+            ...mapObject(aliases.toObject(), (key, value) => new Suggestion({value: key, description: value, style: styles.alias, space: true})),
             ...loginShell.preCommandModifiers.map(modifier => new Suggestion({value: modifier, style: styles.func, space: true})),
             ...executables.map(name => new Suggestion({value: name, description: commandDescriptions[name] || "", style: styles.executable, space: true})),
             ...relativeExecutablesSuggestions,

--- a/src/shell/Scanner.ts
+++ b/src/shell/Scanner.ts
@@ -27,7 +27,7 @@ export class Empty extends Token {
     }
 
     get escapedValue() {
-        return <EscapedShellWord>this.raw.trim();
+        return this.raw.trim() as EscapedShellWord;
     }
 }
 
@@ -37,7 +37,7 @@ export class Word extends Token {
     }
 
     get escapedValue() {
-        return <EscapedShellWord>this.raw.trim();
+        return this.raw.trim() as EscapedShellWord;
     }
 }
 
@@ -47,7 +47,7 @@ export class Pipe extends Token {
     }
 
     get escapedValue(): EscapedShellWord {
-        return <EscapedShellWord>this.value;
+        return this.value as EscapedShellWord;
     }
 }
 
@@ -57,7 +57,7 @@ export class Semicolon extends Token {
     }
 
     get escapedValue(): EscapedShellWord {
-        return <EscapedShellWord>this.value;
+        return this.value as EscapedShellWord;
     }
 }
 
@@ -67,7 +67,7 @@ export class And extends Token {
     }
 
     get escapedValue(): EscapedShellWord {
-        return <EscapedShellWord>this.value;
+        return this.value as EscapedShellWord;
     }
 }
 
@@ -77,7 +77,7 @@ export class Or extends Token {
     }
 
     get escapedValue(): EscapedShellWord {
-        return <EscapedShellWord>this.value;
+        return this.value as EscapedShellWord;
     }
 }
 
@@ -87,7 +87,7 @@ export class InputRedirectionSymbol extends Token {
     }
 
     get escapedValue(): EscapedShellWord {
-        return <EscapedShellWord>this.value;
+        return this.value as EscapedShellWord;
     }
 }
 
@@ -97,7 +97,7 @@ export class OutputRedirectionSymbol extends Token {
     }
 
     get escapedValue(): EscapedShellWord {
-        return <EscapedShellWord>this.value;
+        return this.value as EscapedShellWord;
     }
 }
 
@@ -107,7 +107,7 @@ export class AppendingOutputRedirectionSymbol extends Token {
     }
 
     get escapedValue(): EscapedShellWord {
-        return <EscapedShellWord>this.value;
+        return this.value as EscapedShellWord;
     }
 }
 
@@ -119,13 +119,13 @@ export abstract class StringLiteral extends Token {
 
 export class SingleQuotedStringLiteral extends StringLiteral {
     get escapedValue(): EscapedShellWord {
-        return <EscapedShellWord>`'${this.value}'`;
+        return `'${this.value}'` as EscapedShellWord;
     }
 }
 
 export class DoubleQuotedStringLiteral extends StringLiteral {
     get escapedValue(): EscapedShellWord {
-        return <EscapedShellWord>`"${this.value}"`;
+        return `"${this.value}"` as EscapedShellWord;
     }
 }
 
@@ -135,7 +135,7 @@ export class Invalid extends Token {
     }
 
     get escapedValue(): EscapedShellWord {
-        return <EscapedShellWord>this.value;
+        return this.value as EscapedShellWord;
     }
 }
 
@@ -177,7 +177,7 @@ const patterns = [
         tokenConstructor : SingleQuotedStringLiteral,
     },
     {
-        regularExpression: /^(\s*(?:\\\s|[a-zA-Z0-9\u0080-\uFFFF+~!@#%^&*_=,.:/?\\-])+\s*)/,
+        regularExpression: /^(\s*(?:\\\(|\\\)|\\\s|[a-zA-Z0-9\u0080-\uFFFF+~!@#%^&*_=,.:/?\\-])+\s*)/,
         tokenConstructor : Word,
     },
 ];

--- a/src/views/4_PromptComponent.tsx
+++ b/src/views/4_PromptComponent.tsx
@@ -318,7 +318,14 @@ export class PromptComponent extends React.Component<Props, State> {
     }
 
     private async getSuggestions() {
-        let suggestions = await getSuggestions(this.props.job, getCaretPosition(this.commandNode));
+        let suggestions = await getSuggestions({
+            currentText: this.props.job.prompt.value,
+            currentCaretPosition: getCaretPosition(this.commandNode),
+            ast: this.props.job.prompt.ast,
+            environment: this.props.job.environment,
+            historicalPresentDirectoriesStack: this.props.job.session.historicalPresentDirectoriesStack,
+            aliases: this.props.job.session.aliases,
+        });
 
         this.setState({...this.state, highlightedSuggestionIndex: 0, suggestions: suggestions});
     }

--- a/test/autocompletion_spec.ts
+++ b/test/autocompletion_spec.ts
@@ -1,0 +1,31 @@
+import "mocha";
+import {expect} from "chai";
+import {getSuggestions} from "../src/Autocompletion";
+import {Environment} from "../src/shell/Environment";
+import {OrderedSet} from "../src/utils/OrderedSet";
+import {Aliases} from "../src/shell/Aliases";
+import {CommandWord} from "../src/shell/Parser";
+import {Word} from "../src/shell/Scanner";
+import {styles} from "../src/plugins/autocompletion_utils/Common";
+
+describe("Autocompletion suggestions", () => {
+    it("include aliases", async() => {
+        expect(await getSuggestions({
+            currentText: "myAlia",
+            currentCaretPosition: 6,
+            ast: new CommandWord(new Word("myAlia", 0)),
+            environment: new Environment({}),
+            historicalPresentDirectoriesStack: new OrderedSet<string>(),
+            aliases: new Aliases({
+              myAlias: "expandedAlias",
+            }),
+        })).to.eql([{
+          attributes: {
+            description: "expandedAlias",
+            space: true,
+            style: styles.alias,
+            value: "myAlias",
+          }
+        }]);
+    });
+});

--- a/test/autocompletion_spec.ts
+++ b/test/autocompletion_spec.ts
@@ -6,10 +6,16 @@ import {OrderedSet} from "../src/utils/OrderedSet";
 import {Aliases} from "../src/shell/Aliases";
 import {CommandWord} from "../src/shell/Parser";
 import {Word} from "../src/shell/Scanner";
-import {styles} from "../src/plugins/autocompletion_utils/Common";
+import {
+    styles,
+    anyFilesSuggestions,
+    noEscapeSpacesPromptSerializer
+} from "../src/plugins/autocompletion_utils/Common";
+import {join} from "path";
+import {fontAwesome} from "../src/views/css/FontAwesome";
 
 describe("Autocompletion suggestions", () => {
-    it("include aliases", async() => {
+    it("includes aliases", async() => {
         expect(await getSuggestions({
             currentText: "myAlia",
             currentCaretPosition: 6,
@@ -17,15 +23,29 @@ describe("Autocompletion suggestions", () => {
             environment: new Environment({}),
             historicalPresentDirectoriesStack: new OrderedSet<string>(),
             aliases: new Aliases({
-              myAlias: "expandedAlias",
+                myAlias: "expandedAlias",
             }),
         })).to.eql([{
-          attributes: {
-            description: "expandedAlias",
-            space: true,
-            style: styles.alias,
-            value: "myAlias",
-          }
+            attributes: {
+                description: "expandedAlias",
+                space: true,
+                style: styles.alias,
+                value: "myAlias",
+            }
+        }]);
+    });
+
+    it("wraps file names in quotes if necessary", async() => {
+        expect(await anyFilesSuggestions("fil", join(__dirname, "test_files"))).to.eql([{
+            attributes: {
+                displayValue: "file\\ with\\ brackets\\(\\)",
+                promptSerializer: noEscapeSpacesPromptSerializer,
+                value: "file\\ with\\ brackets\\(\\)",
+                style: {
+                    css: {},
+                    value: fontAwesome.file,
+                },
+            }
         }]);
     });
 });

--- a/test/shell/scanner_spec.ts
+++ b/test/shell/scanner_spec.ts
@@ -155,15 +155,16 @@ describe("scan", () => {
         expect(tokens.map(token => token.value)).to.eql(["test", "space"]);
     });
 
-    describe("invalid input", () => {
-        it("adds an invalid token", async() => {
-            const tokens = scan("cd '");
+    it("handles escaped brackets in words", () => {
+        const tokens = scan("file\\ with\\ brackets\\(\\)");
+        expect(tokens.map(token => token.value)).to.eql(["file with brackets\\(\\)"]);
+    });
 
-            expect(tokens.length).to.eq(2);
-            expect(tokens[0]).to.be.an.instanceof(Word);
-            expect(tokens[1]).to.be.an.instanceof(Invalid);
-
-            expect(tokens.map(token => token.value)).to.eql(["cd", "'"]);
-        });
+    it("adds an invalid token on invalid input", () => {
+        const tokens = scan("cd '");
+        expect(tokens.length).to.eq(2);
+        expect(tokens[0]).to.be.an.instanceof(Word);
+        expect(tokens[1]).to.be.an.instanceof(Invalid);
+        expect(tokens.map(token => token.value)).to.eql(["cd", "'"]);
     });
 });


### PR DESCRIPTION
1) Use `printf` to format autocomplete suggestions
2) Accept backslash escaped `(` and `)` as part of a word in the parser (probably will need other stuff too)
3) Tests for each
4) A couple other misc changes