### PR TITLE
Fix issue causing autocomplete arguments after a space to not work.

### DIFF
--- a/src/Autocompletion.ts
+++ b/src/Autocompletion.ts
@@ -5,6 +5,8 @@ import {Suggestion, styles, replaceAllPromptSerializer} from "./plugins/autocomp
 import {Environment} from "./shell/Environment";
 import {OrderedSet} from "./utils/OrderedSet";
 import {Aliases} from "./shell/Aliases";
+import {AutocompletionProvider} from "./Interfaces";
+
 
 export const suggestionsLimit = 9;
 
@@ -15,6 +17,7 @@ type GetSuggestionsOptions = {
     environment: Environment;
     historicalPresentDirectoriesStack: OrderedSet<string>;
     aliases: Aliases;
+    autocompletionProviderFor: (commandName: string) => AutocompletionProvider;
 };
 
 export const getSuggestions = async({
@@ -24,6 +27,7 @@ export const getSuggestions = async({
     environment,
     historicalPresentDirectoriesStack,
     aliases,
+    autocompletionProviderFor,
 }: GetSuggestionsOptions): Promise<Suggestion[]> => {
     const prefixMatchesInHistory = History.all.filter(line => line.startsWith(currentText));
     const suggestionsFromHistory = prefixMatchesInHistory.map(match => new Suggestion({
@@ -40,6 +44,7 @@ export const getSuggestions = async({
         environment: environment,
         historicalPresentDirectoriesStack: historicalPresentDirectoriesStack,
         aliases: aliases,
+        autocompletionProviderFor: autocompletionProviderFor,
     });
 
     const applicableSuggestions = _.uniqBy(

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -28,6 +28,7 @@ export interface PreliminaryAutocompletionContext {
     readonly environment: Environment;
     readonly historicalPresentDirectoriesStack: OrderedSet<string>;
     readonly aliases: Aliases;
+    readonly autocompletionProviderFor: (commandName: string) => AutocompletionProvider;
 }
 
 export interface AutocompletionContext extends PreliminaryAutocompletionContext {

--- a/src/plugins/autocompletion_utils/Common.ts
+++ b/src/plugins/autocompletion_utils/Common.ts
@@ -77,6 +77,10 @@ export class Suggestion {
         return this.attributes.space || false;
     }
 
+    clone(): Suggestion {
+        return new Suggestion({...this.attributes});
+    }
+
     withValue(value: string): this {
         this.attributes.value = value;
         return this;

--- a/src/shell/Parser.ts
+++ b/src/shell/Parser.ts
@@ -361,7 +361,7 @@ export class CommandWord extends LeafNode {
             ...preCommandModifierSuggestions,
             ...executableSuggestions,
             ...relativeExecutablesSuggestions,
-        ]
+        ];
 
         return allSuggestions;
     }

--- a/src/shell/Parser.ts
+++ b/src/shell/Parser.ts
@@ -5,7 +5,6 @@ import {commandDescriptions} from "../plugins/autocompletion_providers/Executabl
 import {executablesInPaths, mapObject} from "../utils/Common";
 import {loginShell} from "../utils/Shell";
 import {PreliminaryAutocompletionContext} from "../Interfaces";
-import {PluginManager} from "../PluginManager";
 import {Aliases} from "./Aliases";
 import combine from "../plugins/autocompletion_utils/Combine";
 import {
@@ -15,6 +14,7 @@ import {
     environmentVariableSuggestions,
     executableFilesSuggestions,
 } from "../plugins/autocompletion_utils/Common";
+import {OrderedSet} from "../utils/OrderedSet";
 
 
 export abstract class ASTNode {
@@ -24,7 +24,7 @@ export abstract class ASTNode {
 }
 
 abstract class LeafNode extends ASTNode {
-    constructor(private token: Scanner.Token) {
+    constructor(readonly token: Scanner.Token) {
         super();
     }
 
@@ -319,20 +319,51 @@ export class CommandWord extends LeafNode {
     async suggestions({
         environment,
         aliases,
+        autocompletionProviderFor,
     }: PreliminaryAutocompletionContext): Promise<Suggestion[]> {
+        if (this.followingSpaces) {
+            // User is about to enter an argument. Use argument suggestions.
+            const argumentNode = new Argument(new Scanner.Empty(), new Command([this.token]), 1);
+            const argumentSuggestions = await argumentNode.suggestions({
+                environment,
+                aliases,
+                autocompletionProviderFor,
+                historicalPresentDirectoriesStack: new OrderedSet<string>(),
+            });
+            return argumentSuggestions.map(suggestion => suggestion.clone().withValue(this.raw + suggestion.value));
+        }
         if (this.value.length === 0) {
             return [];
         }
-
-        const relativeExecutablesSuggestions = await executableFilesSuggestions(this.value, environment.pwd);
         const executables = await executablesInPaths(environment.path);
 
-        return [
-            ...mapObject(aliases.toObject(), (key, value) => new Suggestion({value: key, description: value, style: styles.alias, space: true})),
-            ...loginShell.preCommandModifiers.map(modifier => new Suggestion({value: modifier, style: styles.func, space: true})),
-            ...executables.map(name => new Suggestion({value: name, description: commandDescriptions[name] || "", style: styles.executable, space: true})),
+        const aliasSuggestions = mapObject(aliases.toObject(), (key, value) => new Suggestion({
+            value: key,
+            description: value,
+            style: styles.alias,
+            space: true,
+        }));
+        const preCommandModifierSuggestions = loginShell.preCommandModifiers.map(modifier => new Suggestion({
+            value: modifier,
+            style: styles.func,
+            space: true,
+        }));
+        const executableSuggestions = executables.map(name => new Suggestion({
+            value: name,
+            description: commandDescriptions[name] || "",
+            style: styles.executable,
+            space: true,
+        }));
+        const relativeExecutablesSuggestions = await executableFilesSuggestions(this.value, environment.pwd);
+
+        const allSuggestions = [
+            ...aliasSuggestions,
+            ...preCommandModifierSuggestions,
+            ...executableSuggestions,
             ...relativeExecutablesSuggestions,
-        ];
+        ]
+
+        return allSuggestions;
     }
 }
 
@@ -366,7 +397,7 @@ export class Argument extends LeafNode {
         const argument = argumentOfExpandedAST(this, context.aliases);
         const provider = combine([
             environmentVariableSuggestions,
-            PluginManager.autocompletionProviderFor(argument.command.commandWord!.value),
+            context.autocompletionProviderFor(argument.command.commandWord!.value),
         ]);
 
         return provider({...context, argument: argument});

--- a/src/views/4_PromptComponent.tsx
+++ b/src/views/4_PromptComponent.tsx
@@ -14,6 +14,7 @@ import * as css from "./css/main";
 import {fontAwesome} from "./css/FontAwesome";
 import {Status} from "../Enums";
 import {scan} from "../shell/Scanner";
+import {PluginManager} from "../PluginManager";
 
 interface Props {
     job: Job;
@@ -325,6 +326,7 @@ export class PromptComponent extends React.Component<Props, State> {
             environment: this.props.job.environment,
             historicalPresentDirectoriesStack: this.props.job.session.historicalPresentDirectoriesStack,
             aliases: this.props.job.session.aliases,
+            autocompletionProviderFor: PluginManager.autocompletionProviderFor.bind(PluginManager),
         });
 
         this.setState({...this.state, highlightedSuggestionIndex: 0, suggestions: suggestions});

--- a/test/autocompletion_spec.ts
+++ b/test/autocompletion_spec.ts
@@ -61,10 +61,7 @@ describe("Autocompletion suggestions", () => {
             environment: new Environment({}),
             historicalPresentDirectoriesStack: new OrderedSet<string>(),
             aliases: new Aliases({}),
-            autocompletionProviderFor: () => async() => {
-                console.log('here');
-                return [new Suggestion({value: "test value"})];
-            },
+            autocompletionProviderFor: () => async() => [new Suggestion({value: "test value"})],
         })).to.eql([{
             attributes: {
                 value: "git test value",

--- a/test/autocompletion_spec.ts
+++ b/test/autocompletion_spec.ts
@@ -7,12 +7,15 @@ import {Aliases} from "../src/shell/Aliases";
 import {CommandWord} from "../src/shell/Parser";
 import {Word} from "../src/shell/Scanner";
 import {
+    Suggestion,
     styles,
     anyFilesSuggestions,
     noEscapeSpacesPromptSerializer,
 } from "../src/plugins/autocompletion_utils/Common";
 import {join} from "path";
 import {fontAwesome} from "../src/views/css/FontAwesome";
+import {PluginManager} from "../src/PluginManager";
+
 
 describe("Autocompletion suggestions", () => {
     it("includes aliases", async() => {
@@ -25,6 +28,7 @@ describe("Autocompletion suggestions", () => {
             aliases: new Aliases({
                 myAlias: "expandedAlias",
             }),
+            autocompletionProviderFor: PluginManager.autocompletionProviderFor.bind(PluginManager),
         })).to.eql([{
             attributes: {
                 description: "expandedAlias",
@@ -45,6 +49,25 @@ describe("Autocompletion suggestions", () => {
                     css: {},
                     value: fontAwesome.file,
                 },
+            },
+        }]);
+    });
+
+    it("takes trailing spaces into account (regression test for #933)", async() => {
+        expect(await getSuggestions({
+            currentText: "git ",
+            currentCaretPosition: 4,
+            ast: new CommandWord(new Word("git ", 0)),
+            environment: new Environment({}),
+            historicalPresentDirectoriesStack: new OrderedSet<string>(),
+            aliases: new Aliases({}),
+            autocompletionProviderFor: () => async() => {
+                console.log('here');
+                return [new Suggestion({value: "test value"})];
+            },
+        })).to.eql([{
+            attributes: {
+                value: "git test value",
             },
         }]);
     });


### PR DESCRIPTION
Fixes #933 by treating special casing completion for `CommandWord` if there is a space after the command. This was formerly impossible, but became possible after #903.