### PR TITLE
Unify subcommand autocomplete

### DIFF
--- a/src/plugins/autocompletion_providers/Git.ts
+++ b/src/plugins/autocompletion_providers/Git.ts
@@ -1,7 +1,7 @@
 import * as Git from "../../utils/Git";
 import {
     styles, Suggestion, longAndShortFlag, longFlag, mapSuggestions, unique,
-    emptyProvider, SubcommandConfig, commandWithSubcommands
+    emptyProvider, SubcommandConfig, commandWithSubcommands,
 } from "../autocompletion_utils/Common";
 import * as Common from "../autocompletion_utils/Common";
 import combine from "../autocompletion_utils/Combine";

--- a/src/plugins/autocompletion_providers/NPM.ts
+++ b/src/plugins/autocompletion_providers/NPM.ts
@@ -1,7 +1,8 @@
 import * as Path from "path";
-import {Suggestion, styles} from "../autocompletion_utils/Common";
+import {Suggestion, styles, commandWithSubcommands} from "../autocompletion_utils/Common";
 import {exists, readFile, mapObject} from "../../utils/Common";
 import {PluginManager} from "../../PluginManager";
+import {AutocompletionContext} from "../../Interfaces";
 
 const npmCommandConfig = [
     {
@@ -147,6 +148,15 @@ const npmCommandConfig = [
     {
         name: "run",
         description: "Run arbitrary package scripts",
+        completion: async (context: AutocompletionContext) => {
+            const packageFilePath = Path.join(context.environment.pwd, "package.json");
+            if (await exists(packageFilePath)) {
+                const parsed = JSON.parse(await readFile(packageFilePath)).scripts || {};
+                return mapObject(parsed, (key: string, value: string) => new Suggestion({value: key, description: value, style: styles.command}));
+            } else {
+                return [];
+            }
+        },
     },
     {
         name: "search",
@@ -210,29 +220,4 @@ const npmCommandConfig = [
     },
 ];
 
-const npmCommand = npmCommandConfig.map(config => new Suggestion({value: config.name, description: config.description, style: styles.command}));
-
-PluginManager.registerAutocompletionProvider("npm", async (context) => {
-    if (context.argument.position === 1) {
-        return npmCommand;
-    } else if (context.argument.position === 2) {
-        const firstArgument = context.argument.command.nthArgument(1);
-
-        if (firstArgument && firstArgument.value === "run") {
-            const packageFilePath = Path.join(context.environment.pwd, "package.json");
-
-            if (await exists(packageFilePath)) {
-                const parsed = JSON.parse(await readFile(packageFilePath)).scripts || {};
-                return mapObject(parsed, (key: string, value: string) => new Suggestion({value: key, description: value, style: styles.command}));
-            } else {
-                return [];
-            }
-        } else {
-            // TODO: handle npm sub commands other than "run" that can be
-            // further auto-completed
-            return [];
-        }
-    } else {
-        return [];
-    }
-});
+PluginManager.registerAutocompletionProvider("npm", commandWithSubcommands(npmCommandConfig));

--- a/src/plugins/autocompletion_providers/NPM.ts
+++ b/src/plugins/autocompletion_providers/NPM.ts
@@ -148,7 +148,7 @@ const npmCommandConfig = [
     {
         name: "run",
         description: "Run arbitrary package scripts",
-        completion: async (context: AutocompletionContext) => {
+        provider: async (context: AutocompletionContext) => {
             const packageFilePath = Path.join(context.environment.pwd, "package.json");
             if (await exists(packageFilePath)) {
                 const parsed = JSON.parse(await readFile(packageFilePath)).scripts || {};

--- a/src/plugins/autocompletion_providers/NPM.ts
+++ b/src/plugins/autocompletion_providers/NPM.ts
@@ -152,7 +152,11 @@ const npmCommandConfig = [
             const packageFilePath = Path.join(context.environment.pwd, "package.json");
             if (await exists(packageFilePath)) {
                 const parsed = JSON.parse(await readFile(packageFilePath)).scripts || {};
-                return mapObject(parsed, (key: string, value: string) => new Suggestion({value: key, description: value, style: styles.command}));
+                return mapObject(parsed, (key: string, value: string) => new Suggestion({
+                    value: key,
+                    description: value,
+                    style: styles.command,
+                }));
             } else {
                 return [];
             }

--- a/src/plugins/autocompletion_providers/Rails.ts
+++ b/src/plugins/autocompletion_providers/Rails.ts
@@ -1,4 +1,4 @@
-import {styles, Suggestion} from "../autocompletion_utils/Common";
+import {commandWithSubcommands} from "../autocompletion_utils/Common";
 import {PluginManager} from "../../PluginManager";
 
 const railsCommandConfig = [
@@ -36,6 +36,4 @@ const railsCommandConfig = [
     },
 ];
 
-const railsCommand = railsCommandConfig.map(config => new Suggestion({value: config.name, description: config.description, style: styles.command}));
-
-PluginManager.registerAutocompletionProvider("rails", async() => railsCommand);
+PluginManager.registerAutocompletionProvider("rails", commandWithSubcommands(railsCommandConfig));

--- a/src/plugins/autocompletion_providers/Vagrant.ts
+++ b/src/plugins/autocompletion_providers/Vagrant.ts
@@ -1,35 +1,31 @@
 import {PluginManager} from "../../PluginManager";
 import {linedOutputOf} from "../../PTY";
 import {commandWithSubcommands, emptyProvider, SubcommandConfig} from "../autocompletion_utils/Common";
-import {executablesInPaths} from "../../utils/Common";
 import {once} from "lodash";
 
 const vargrantCommandConfig = once(async() => {
-    const vagrantCommandListLines = await linedOutputOf("vagrant", ["list-commands"], process.env.HOME);
-    return vagrantCommandListLines
-        .map(line => {
-            const matches = line.match(/([\-a-zA-Z0-9]+)  /);
+    try {
+        return (await linedOutputOf("vagrant", ["list-commands"], process.env.HOME))
+            .map(line => {
+                const matches = line.match(/([\-a-zA-Z0-9]+)  /);
 
-            if (matches) {
-                const name = matches[1];
-                const description = line.replace(matches[1], "").trim();
+                if (matches) {
+                    const name = matches[1];
+                    const description = line.replace(matches[1], "").trim();
 
-                return {
-                    name,
-                    description,
-                    completion: emptyProvider,
-                };
-            }
-        })
-        .filter(suggestion => suggestion) as SubcommandConfig[];
+                    return {
+                        name,
+                        description,
+                        provider: emptyProvider,
+                    };
+                }
+            })
+            .filter(suggestion => suggestion) as SubcommandConfig[];
+    } catch (e) {
+        return [] as SubcommandConfig[];
+    }
 });
 
 PluginManager.registerAutocompletionProvider("vagrant", async (context) => {
-    const executables = await executablesInPaths(context.environment.path);
-
-    if (!executables.includes("vagrant")) {
-        return [];
-    }
-
     return commandWithSubcommands(await vargrantCommandConfig())(context);
 });

--- a/src/plugins/autocompletion_utils/Common.ts
+++ b/src/plugins/autocompletion_utils/Common.ts
@@ -359,24 +359,24 @@ export const mapSuggestions = (provider: AutocompletionProvider, mapper: (sugges
 export interface SubcommandConfig {
     name: string;
     description: string;
-    completion?: AutocompletionProvider;
+    provider?: AutocompletionProvider;
 };
 
 export const commandWithSubcommands = (subCommands: SubcommandConfig[]) => {
     return async (context: AutocompletionContext) => {
         if (context.argument.position === 1) {
-            return subCommands.map(({ name, description, completion }) => new Suggestion({
+            return subCommands.map(({ name, description, provider }) => new Suggestion({
                 value: name,
                 description,
                 style: styles.command,
-                space: completion !== undefined,
+                space: provider !== undefined,
             }));
         } else if (context.argument.position === 2) {
             const firstArgument = context.argument.command.nthArgument(1);
             if (firstArgument) {
                 const subCommandConfig = subCommands.find(config => config.name === firstArgument.value);
-                if (subCommandConfig && subCommandConfig.completion) {
-                    return await subCommandConfig.completion(context);
+                if (subCommandConfig && subCommandConfig.provider) {
+                    return await subCommandConfig.provider(context);
                 }
             }
         } else {

--- a/src/plugins/autocompletion_utils/Common.ts
+++ b/src/plugins/autocompletion_utils/Common.ts
@@ -355,3 +355,18 @@ export const shortFlag = (char: string) => unique(async() => [new Suggestion({va
 export const longFlag = (name: string) => unique(async() => [new Suggestion({value: `--${name}`, style: styles.option})]);
 
 export const mapSuggestions = (provider: AutocompletionProvider, mapper: (suggestion: Suggestion) => Suggestion) => mk(async(context) => (await provider(context)).map(mapper));
+
+interface SubcommandConfig {
+    name: string;
+    description: string;
+};
+
+export const commandWithSubcommands = (subcommands: SubcommandConfig[]) => {
+    return async () => {
+        return subcommands.map(({ name, description }) => new Suggestion({
+            value: name,
+            description,
+            style: styles.command,
+        }));
+    }
+}

--- a/src/plugins/autocompletion_utils/Common.ts
+++ b/src/plugins/autocompletion_utils/Common.ts
@@ -356,7 +356,7 @@ export const longFlag = (name: string) => unique(async() => [new Suggestion({val
 
 export const mapSuggestions = (provider: AutocompletionProvider, mapper: (suggestion: Suggestion) => Suggestion) => mk(async(context) => (await provider(context)).map(mapper));
 
-interface SubcommandConfig {
+export interface SubcommandConfig {
     name: string;
     description: string;
     completion?: AutocompletionProvider;
@@ -365,10 +365,11 @@ interface SubcommandConfig {
 export const commandWithSubcommands = (subCommands: SubcommandConfig[]) => {
     return async (context: AutocompletionContext) => {
         if (context.argument.position === 1) {
-            return subCommands.map(({ name, description }) => new Suggestion({
+            return subCommands.map(({ name, description, completion }) => new Suggestion({
                 value: name,
                 description,
                 style: styles.command,
+                space: completion !== undefined,
             }));
         } else if (context.argument.position === 2) {
             const firstArgument = context.argument.command.nthArgument(1);

--- a/src/plugins/autocompletion_utils/Common.ts
+++ b/src/plugins/autocompletion_utils/Common.ts
@@ -358,17 +358,20 @@ export const mapSuggestions = (provider: AutocompletionProvider, mapper: (sugges
 
 export interface SubcommandConfig {
     name: string;
-    description: string;
+    description?: string;
+    synopsis?: string;
+    style?: Style;
     provider?: AutocompletionProvider;
 };
 
 export const commandWithSubcommands = (subCommands: SubcommandConfig[]) => {
     return async (context: AutocompletionContext) => {
         if (context.argument.position === 1) {
-            return subCommands.map(({ name, description, provider }) => new Suggestion({
+            return subCommands.map(({ name, description, synopsis, provider, style }) => new Suggestion({
                 value: name,
                 description,
-                style: styles.command,
+                synopsis,
+                style: style || styles.command,
                 space: provider !== undefined,
             }));
         } else if (context.argument.position === 2) {
@@ -379,8 +382,7 @@ export const commandWithSubcommands = (subCommands: SubcommandConfig[]) => {
                     return await subCommandConfig.provider(context);
                 }
             }
-        } else {
-            return []
         }
-    }
-}
+        return [];
+    };
+};


### PR DESCRIPTION
Create a reusable abstraction for commands with subcommands, and have the `Git`, `NPM`, and `Vagrant` autocompletion providers use it.