### PR TITLE
Finally fix autocomplete after space and also plugins without words

### DIFF
--- a/src/shell/Job.ts
+++ b/src/shell/Job.ts
@@ -14,6 +14,7 @@ import {Environment} from "./Environment";
 import {normalizeKey} from "../utils/Common";
 import {TerminalLikeDevice} from "../Interfaces";
 import {History} from "./History";
+import {Invalid} from "./Scanner";
 
 function makeThrottledDataEmitter(timesPerSecond: number, subject: EmitterWithUniqueID) {
     return _.throttle(() => subject.emit("data"), 1000 / timesPerSecond);
@@ -69,7 +70,9 @@ export class Job extends EmitterWithUniqueID implements TerminalLikeDevice {
             this.setStatus(Status.InProgress);
         }
 
-        const commandWords: string[] = this.prompt.expandedTokens.map(token => token.escapedValue);
+        const commandWords: string[] = this.prompt.expandedTokens
+            .filter(token => !(token instanceof Invalid))
+            .map(token => token.escapedValue);
         const interceptorOptions = {
             command: commandWords,
             presentWorkingDirectory: this.environment.pwd,

--- a/src/shell/Scanner.ts
+++ b/src/shell/Scanner.ts
@@ -145,39 +145,39 @@ const patterns = [
         tokenConstructor: Pipe,
     },
     {
-        regularExpression: /^(\s*;\s*)/,
+        regularExpression: /^(\s*;)/,
         tokenConstructor: Semicolon,
     },
     {
-        regularExpression: /^(\s*&&\s*)/,
+        regularExpression: /^(\s*&&)/,
         tokenConstructor: And,
     },
     {
-        regularExpression: /^(\s*\|\|\s*)/,
+        regularExpression: /^(\s*\|\|)/,
         tokenConstructor: Or,
     },
     {
-        regularExpression: /^(\s*>>\s*)/,
+        regularExpression: /^(\s*>>)/,
         tokenConstructor: AppendingOutputRedirectionSymbol,
     },
     {
-        regularExpression: /^(\s*<\s*)/,
+        regularExpression: /^(\s*<)/,
         tokenConstructor: InputRedirectionSymbol,
     },
     {
-        regularExpression: /^(\s*>\s*)/,
+        regularExpression: /^(\s*>)/,
         tokenConstructor: OutputRedirectionSymbol,
     },
     {
-        regularExpression: /^(\s*"(?:\\"|[^"])*"\s*)/,
+        regularExpression: /^(\s*"(?:\\"|[^"])*")/,
         tokenConstructor: DoubleQuotedStringLiteral,
     },
     {
-        regularExpression: /^(\s*'(?:\\'|[^'])*'\s*)/,
+        regularExpression: /^(\s*'(?:\\'|[^'])*')/,
         tokenConstructor : SingleQuotedStringLiteral,
     },
     {
-        regularExpression: /^(\s*(?:\\\(|\\\)|\\\s|[a-zA-Z0-9\u0080-\uFFFF+~!@#%^&*_=,.:/?\\-])+\s*)/,
+        regularExpression: /^(\s*(?:\\\(|\\\)|\\\s|[a-zA-Z0-9\u0080-\uFFFF+~!@#%^&*_=,.:/?\\-])+)/,
         tokenConstructor : Word,
     },
 ];

--- a/test/shell/scanner_spec.ts
+++ b/test/shell/scanner_spec.ts
@@ -152,7 +152,7 @@ describe("scan", () => {
 
     it("includes spaces at end in final token", () => {
         const tokens = scan("test space ");
-        expect(tokens.map(token => token.value)).to.eql(["test", "space"]);
+        expect(tokens.map(token => token.value)).to.eql(["test", "space", ""]);
     });
 
     it("handles escaped brackets in words", () => {


### PR DESCRIPTION
Fixes #938

I realized that there are two conflicting issues here: autocomplete cares about spaces, and wants them to not be removed, and plugins don't care about spaces, and want them to be removed. All my approaches so far had been to deal with whitespace at the parser level and then try to make autocomplete happy, bit I realized it's much simpler to leave the parser as-is, and filter out `Invalid` tokens before handing them to the plugins.

This PR reverts my changes to "eat" whitespace at the end of tokens, which fixes autocomplete, and filters `Invalid` tokens out of commands before handing to plugins.