### PR TITLE
Fix a crash where PTY isn't launched

### DIFF
--- a/src/EmitterWithUniqueID.ts
+++ b/src/EmitterWithUniqueID.ts
@@ -1,10 +1,13 @@
 import * as events from "events";
 
+let nextId = 0;
+
 export class EmitterWithUniqueID extends events.EventEmitter {
     public id: number;
 
     constructor() {
         super();
-        this.id = new Date().getTime();
+        this.id = nextId;
+        nextId++;
     }
 }

--- a/src/shell/CommandExecutor.ts
+++ b/src/shell/CommandExecutor.ts
@@ -58,13 +58,13 @@ class ShellExecutionStrategy extends CommandExecutionStrategy {
 
     startExecution() {
         return new Promise((resolve, reject) => {
-            this.job.command = new PTY(
+            this.job.setPty(new PTY(
                 this.job.prompt.expandedTokens.map(token => token.escapedValue),
                 this.job.environment.toObject(),
                 this.job.dimensions,
                 (data: string) => this.job.parser.parse(data),
                 (exitCode: number) => exitCode === 0 ? resolve() : reject(new NonZeroExitCodeError(exitCode.toString())),
-            );
+            ));
         });
     }
 }
@@ -76,27 +76,27 @@ class WindowsShellExecutionStrategy extends CommandExecutionStrategy {
 
     startExecution() {
         return new Promise((resolve) => {
-            this.job.command = new PTY(
+            this.job.setPty(new PTY(
                 [
                     this.cmdPath,
-                    <EscapedShellWord>"/s",
-                    <EscapedShellWord>"/c",
+                    "/s" as EscapedShellWord,
+                    "/c" as EscapedShellWord,
                     ...this.job.prompt.expandedTokens.map(token => token.escapedValue),
                 ],
                 this.job.environment.toObject(), this.job.dimensions,
                 (data: string) => this.job.parser.parse(data),
                 (_exitCode: number) => resolve(),
-            );
+            ));
         });
     }
 
     private get cmdPath(): EscapedShellWord {
         if (this.job.environment.has("comspec")) {
-            return <EscapedShellWord>this.job.environment.get("comspec");
+            return this.job.environment.get("comspec") as EscapedShellWord;
         } else if (this.job.environment.has("SystemRoot")) {
-            return <EscapedShellWord>Path.join(this.job.environment.get("SystemRoot"), "System32", "cmd.exe");
+            return Path.join(this.job.environment.get("SystemRoot"), "System32", "cmd.exe") as EscapedShellWord;
         } else {
-            return <EscapedShellWord>"cmd.exe";
+            return "cmd.exe" as EscapedShellWord;
         }
     }
 }

--- a/src/views/UserEventsHander.ts
+++ b/src/views/UserEventsHander.ts
@@ -3,7 +3,7 @@ import {SessionComponent} from "./2_SessionComponent";
 import {PromptComponent} from "./4_PromptComponent";
 import {JobComponent} from "./3_JobComponent";
 import {Tab} from "./TabComponent";
-import {Status, KeyboardAction} from "../Enums";
+import {KeyboardAction} from "../Enums";
 import {isModifierKey} from "./ViewUtils";
 import {SearchComponent} from "./SearchComponent";
 import {remote} from "electron";
@@ -25,7 +25,7 @@ export const handleUserEvent = (
             return;
         }
 
-        if (!isInProgress(job)) {
+        if (!job.props.job.isInProgress()) {
             prompt.focus();
             event.preventDefault();
             prompt.appendText(event.clipboardData.getData("text/plain"));
@@ -41,7 +41,7 @@ export const handleUserEvent = (
     }
 
     // Close focused pane
-    if (isKeybindingForEvent(event, KeyboardAction.paneClose) && !isInProgress(job)) {
+    if (isKeybindingForEvent(event, KeyboardAction.paneClose) && !job.props.job.isInProgress()) {
         application.closeFocusedPane();
 
         application.forceUpdate();
@@ -76,7 +76,7 @@ export const handleUserEvent = (
     }
 
     // Console clear
-    if (isKeybindingForEvent(event, KeyboardAction.cliClearJobs) && !isInProgress(job)) {
+    if (isKeybindingForEvent(event, KeyboardAction.cliClearJobs) && !job.props.job.isInProgress()) {
         session.props.session.clearJobs();
 
         event.stopPropagation();
@@ -105,7 +105,7 @@ export const handleUserEvent = (
     }
 
 
-    if (isInProgress(job) && !isModifierKey(event)) {
+    if (job.props.job.isRunningPty() && !isModifierKey(event)) {
         // CLI interrupt
         if (isKeybindingForEvent(event, KeyboardAction.cliInterrupt)) {
             job.props.job.interrupt();
@@ -129,7 +129,7 @@ export const handleUserEvent = (
         return;
     }
 
-    if (!isInProgress(job)) {
+    if (!job.props.job.isInProgress()) {
         // CLI Delete word
         if (isKeybindingForEvent(event, KeyboardAction.cliDeleteWord)) {
             prompt.deleteWord();
@@ -204,10 +204,6 @@ export const handleUserEvent = (
 
     prompt.setPreviousKeyCode(event);
 };
-
-function isInProgress(job: JobComponent): boolean {
-    return job.props.job.status === Status.InProgress;
-}
 
 const app = remote.app;
 const browserWindow = remote.BrowserWindow.getAllWindows()[0];


### PR DESCRIPTION
There is a brief window in between when the `Job`'s `status` is set to `InProgress`, and when it's `PTY` is created. If the user types a key in that window, `job.write` will be called, which expects the `PTY` to exist, but it doesn't, causing a crash. This PR fixes that issue.

In general, I think we should move away from using `job.status`, and instead, have methods that check exactly what the caller wants to know about the job. `job.status` is essentially supposed to be a reflection of the `job`'s internal state, but because of all the `async` stuff in there, it's just not very good at doing that.