### PR TITLE
fix autocomplete on linux

### DIFF
--- a/src/PTY.ts
+++ b/src/PTY.ts
@@ -65,6 +65,7 @@ export function executeCommand(
             ...execOptions,
             env: _.extend({PWD: directory}, process.env),
             cwd: directory,
+            shell: "/bin/bash",
         };
 
         ChildProcess.exec(`${command} ${args.join(" ")}`, options, (error, output) => {


### PR DESCRIPTION
On linux autocompletion doesn't work and `npm test` fail on autocompletion because of
`/bin/sh: 1: printf: %q: invalid directive`

Setting child_process default shell to /bin/bash fix autocompletion and tests.
I don't know if it causes any issues on osx, but on linux it works like a charm.