### PR TITLE
Fix scanner splitting literals with quotes (#957)

### DIFF
--- a/test/shell/scanner_spec.ts
+++ b/test/shell/scanner_spec.ts
@@ -1,6 +1,6 @@
 import {expect} from "chai";
 import {
-    scan, Word, DoubleQuotedStringLiteral, SingleQuotedStringLiteral,
+    scan, Word, DoubleQuotedStringLiteral, SingleQuotedStringLiteral, CompositeStringLiteral,
     Pipe, OutputRedirectionSymbol, AppendingOutputRedirectionSymbol, InputRedirectionSymbol, Invalid, Semicolon,
 } from "../../src/shell/Scanner";
 
@@ -46,6 +46,17 @@ describe("scan", () => {
         expect(tokens[1]).to.be.an.instanceof(SingleQuotedStringLiteral);
 
         expect(tokens.map(token => token.value)).to.eql(["prefix", "inside quotes"]);
+    });
+
+    it("doesn't split string literals with no spaces between them", () => {
+        const tokens = scan("echo a'b'\"c\" d");
+
+        expect(tokens.length).to.eq(3);
+        expect(tokens[0]).to.be.an.instanceof(Word);
+        expect(tokens[1]).to.be.an.instanceof(CompositeStringLiteral);
+        expect(tokens[2]).to.be.an.instanceof(Word);
+
+        expect(tokens.map(token => token.value)).to.eql(["echo", "abc", "d"]);
     });
 
     it("doesn't split on an escaped space", () => {


### PR DESCRIPTION
Fixes https://github.com/vshatskyi/black-screen/issues/957

The problem is that Scanner splits tokens made up of several string literals, like key="value". The solution is to squash literals into composite literals if there are no spaces between them.

I moved StringLiteral class because it needs to be above Word class, because Word now extends StringLiteral.