### PR TITLE
Renamed 'electron-prebuilt' to 'electron'

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "devtron": "1.4.0",
     "electron-builder": "11.4.4",
     "electron-mocha": "3.3.0",
-    "electron-prebuilt": "1.4.13",
+    "electron": "1.4.13",
     "electron-rebuild": "1.5.7",
     "enzyme": "2.7.1",
     "mocha": "3.2.0",


### PR DESCRIPTION
I renamed 'electron-prebuilt' to 'electron' in package.json file. The 'electron-prebuilt' package name has been deprecated and was causing errors when running on my Ubuntu development machine (running Ubuntu 16.04.2 LTS with node.js 7.6.0).