### PR TITLE
Fixes #978

### DIFF
--- a/src/views/keyevents/Keybindings.ts
+++ b/src/views/keyevents/Keybindings.ts
@@ -195,7 +195,7 @@ export const KeybindingsForMenu: KeybindingMenuType[] = [
     },
     {
         action: KeyboardAction.viewToggleFullScreen,
-        accelerator: "CmdOrCtrl+Shift+F",
+        accelerator: "Ctrl+Cmd+F",
     },
     // black screen commands
     {


### PR DESCRIPTION
Changes the keybinding for toggling full screen to match MacOS conventions, as found in other apps.