### PR TITLE
Support combinations of short flags for auto-completion providers

### DIFF
--- a/src/plugins/autocompletion_providers/Ls.ts
+++ b/src/plugins/autocompletion_providers/Ls.ts
@@ -1,6 +1,8 @@
 import {PluginManager} from "../../PluginManager";
-import {directoriesSuggestionsProvider} from "../autocompletion_utils/Common";
+import {directoriesSuggestionsProvider, combineShortFlags} from "../autocompletion_utils/Common";
 import combine from "../autocompletion_utils/Combine";
 import {manPageOptions} from "../../utils/ManPages";
 
-PluginManager.registerAutocompletionProvider("ls", combine([directoriesSuggestionsProvider, manPageOptions("ls")]));
+const lsOptions = combineShortFlags(manPageOptions("ls"));
+
+PluginManager.registerAutocompletionProvider("ls", combine([directoriesSuggestionsProvider, lsOptions]));

--- a/src/plugins/autocompletion_utils/Common.ts
+++ b/src/plugins/autocompletion_utils/Common.ts
@@ -386,3 +386,24 @@ export const commandWithSubcommands = (subCommands: SubcommandConfig[]) => {
         return [];
     };
 };
+
+export const combineShortFlags = (suggestionsProvider: AutocompletionProvider) => {
+    return async (context: AutocompletionContext) => {
+        const token = context.argument.value;
+        const reShortFlag = new RegExp(/^\-[a-zA-Z]$/);
+        const reShortFlags = new RegExp(/^\-[a-zA-Z]+$/);
+        const suggestions = await suggestionsProvider(context);
+        if (reShortFlags.test(token)) {
+            return suggestions
+                    .filter(s =>
+                        reShortFlag.test(s.value) && !token.includes(s.value.slice(1))
+                            && s.withSpace)
+                    .map(s =>
+                        new Suggestion({value: token + s.value.slice(1),
+                            displayValue: s.displayValue, description: s.description,
+                            style: s.style}));
+        } else {
+            return suggestions;
+        }
+    };
+};


### PR DESCRIPTION
Added function 'combineShortFlags' to support entry of short flag combinations for auto-complete providers.